### PR TITLE
Minor fix and assorted cleanup

### DIFF
--- a/maven-windows-service-installer-plugin/pom.xml
+++ b/maven-windows-service-installer-plugin/pom.xml
@@ -10,22 +10,6 @@
     <packaging>maven-plugin</packaging>
     <name>Maven Windows Service Installer Plugin</name>
 
-    <description>
-        Maven plugin to build installers with Windows service support.
-    </description>
-    <url>https://github.com/alexkasko/windows-service-installer</url>
-    <licenses>
-        <license>
-            <name>Apache License 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-    </licenses>
-    <scm>
-        <url>https://github.com/alexkasko/windows-service-installer</url>
-        <connection>scm:git:https://github.com/alexkasko/windows-service-installer.git</connection>
-        <developerConnection>scm:git:https://github.com/alexkasko/windows-service-installer.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
     <developers>
         <developer>
             <name>Alex Kasko</name>
@@ -68,7 +52,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>3.0.3.RELEASE</version>
+            <version>4.1.6.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/maven-windows-service-installer-plugin/src/main/java/com/alexkasko/installer/InstallerMojo.java
+++ b/maven-windows-service-installer-plugin/src/main/java/com/alexkasko/installer/InstallerMojo.java
@@ -286,8 +286,8 @@ public class InstallerMojo extends SettingsMojo {
                 OutputStream out = null;
                 try {
                     file = new File(dir, name.substring(0, name.length() - 4));
-                    OutputStream os = openOutputStream(file);
-                    freemarker.process(input.getInputStream(), InstallerMojo.this, os, ftlOutputEncoding);
+                    out = openOutputStream(file);
+                    freemarker.process(input.getInputStream(), InstallerMojo.this, out, ftlOutputEncoding);
                 } catch (IOException e) {
                     throw new UnhandledException(e);
                 } finally {

--- a/maven-windows-service-installer-plugin/src/main/java/com/alexkasko/installer/SettingsMojo.java
+++ b/maven-windows-service-installer-plugin/src/main/java/com/alexkasko/installer/SettingsMojo.java
@@ -1,10 +1,8 @@
 package com.alexkasko.installer;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.project.MavenProject;
-import ru.concerteza.util.io.CtzResourceUtils;
 
 import java.io.File;
 import java.util.List;
@@ -23,7 +21,7 @@ public abstract class SettingsMojo extends AbstractMojo {
     /**
      * Application directories to be included into installer
      *
-     * @parameter expression="${installer.appDataDirs}"
+     * @parameter property="${installer.appDataDirs}"
      * @required
      */
     protected List<String> appDataDirs;
@@ -33,44 +31,44 @@ public abstract class SettingsMojo extends AbstractMojo {
     /**
      * Path to windows JRE
      *
-     * @parameter expression="${installer.jreDir}" default-value="${java.home}"
+     * @parameter property="${installer.jreDir}" default-value="${java.home}"
      */
     protected File jreDir;
     /**
      * Whether JRE is 64 bit
      *
-     * @parameter expression="${installer.use64BitJre}" default-value="false"
+     * @parameter property="${installer.use64BitJre}" default-value="false"
      */
     protected boolean use64BitJre;
     /**
      * Use x86 launcher binaries for x64 installers instead of default x64 ones
      *
-     * @parameter expression="${installer.useX86LaunchersForX64Installer}" default-value="false"
+     * @parameter property="${installer.useX86LaunchersForX64Installer}" default-value="false"
      *
      */
     protected boolean useX86LaunchersForX64Installer;
     /**
      * Resource path to x86 installer launcher
      *
-     * @parameter expression="${installer.installLauncher32Path}" default-value="classpath:/launchers/x86/install.exe"
+     * @parameter property="${installer.installLauncher32Path}" default-value="classpath:/launchers/x86/install.exe"
      */
     protected String installLauncher32Path;
     /**
      * Resource path to x86 uninstaller launcher
      *
-     * @parameter expression="${installer.uninstallLauncher32Path}" default-value="classpath:/launchers/x86/uninstall.exe"
+     * @parameter property="${installer.uninstallLauncher32Path}" default-value="classpath:/launchers/x86/uninstall.exe"
      */
     protected String uninstallLauncher32Path;
     /**
      * Resource path to x64 installer launcher
      *
-     * @parameter expression="${installer.uninstallLauncher32Path}" default-value="classpath:/launchers/x64/install.exe"
+     * @parameter property="${installer.uninstallLauncher32Path}" default-value="classpath:/launchers/x64/install.exe"
      */
     protected String installLauncher64Path;
     /**
      * Resource path to x64 uninstaller launcher
      *
-     * @parameter expression="${installer.uninstallLauncher32Path}" default-value="classpath:/launchers/x64/uninstall.exe"
+     * @parameter property="${installer.uninstallLauncher32Path}" default-value="classpath:/launchers/x64/uninstall.exe"
      */
     protected String uninstallLauncher64Path;
 
@@ -79,92 +77,92 @@ public abstract class SettingsMojo extends AbstractMojo {
     /**
      * Application name displayed in installer
      *
-     * @parameter expression="${installer.izpackAppName}" default-value="${project.name}"
+     * @parameter property="${installer.izpackAppName}" default-value="${project.name}"
      */
     protected String izpackAppName;
     /**
      * Application version displayed in installer
      *
-     * @parameter expression="${installer.izpackAppVersion}" default-value="${project.version}"
+     * @parameter property="${installer.izpackAppVersion}" default-value="${project.version}"
      */
     protected String izpackAppVersion;
     /**
      * Installer language, see http://izpack.org/documentation/installation-files.html#the-localization-element-locale
      *
-     * @parameter expression="${installer.izpackLang}" default-value="xxx"
+     * @parameter property="${installer.izpackLang}" default-value="xxx"
      */
     protected String izpackLang;
     /**
      * Installer compress option, values are 'raw' (default), 'deflate' and 'bzip2'
      *
-     * @parameter expression="${installer.izpackCompress}" default-value="raw"
+     * @parameter property="${installer.izpackCompress}" default-value="raw"
      */
     protected String izpackCompress;
     /**
      * Default installation directory
      *
-     * @parameter expression="${installer.izpackDefaultInstallDir}" default-value="$USER_HOME\\${project.name}"
+     * @parameter property="${installer.izpackDefaultInstallDir}" default-value="$USER_HOME\\${project.name}"
      */
     protected String izpackDefaultInstallDir;
     /**
      * Application Files pack name
      *
-     * @parameter expression="${installer.izpackAppFilesPackName}" default-value="Application Files"
+     * @parameter property="${installer.izpackAppFilesPackName}" default-value="Application Files"
      */
     protected String izpackAppFilesPackName;
     /**
      * Application Files pack description
      *
-     * @parameter expression="${installer.izpackAppFilesPackDescription}" default-value="Necessary application files"
+     * @parameter property="${installer.izpackAppFilesPackDescription}" default-value="Necessary application files"
      */
     protected String izpackAppFilesPackDescription;
     /**
      * JRE pack name
      *
-     * @parameter expression="${installer.izpackJREPackName}" default-value="Java Runtime Environment"
+     * @parameter property="${installer.izpackJREPackName}" default-value="Java Runtime Environment"
      */
     protected String izpackJREPackName;
     /**
      * JRE pack description
      *
-     * @parameter expression="${installer.izpackJREPackName}" default-value="Java Runtime Environment"
+     * @parameter property="${installer.izpackJREPackName}" default-value="Java Runtime Environment"
      */
     protected String izpackJREPackDescription;
     /**
      * Windows Service pack name
      *
-     * @parameter expression="${installer.izpackWindowsServicePackName}" default-value="Windows Service Installer"
+     * @parameter property="${installer.izpackWindowsServicePackName}" default-value="Windows Service Installer"
      */
     protected String izpackWindowsServicePackName;
     /**
      * Windows Service pack description
      *
-     * @parameter expression="${installer.izpackWindowsServicePackDescription}"
+     * @parameter property="${installer.izpackWindowsServicePackDescription}"
      * default-value="Application will be installed as Windows Service using prunsrv tool from Apache Commons Daemon project, see http://commons.apache.org/daemon"
      */
     protected String izpackWindowsServicePackDescription;
     /**
      * Icon to be used on top of installer frame
      *
-     * @parameter expression="${installer.izpackFrameIconPath}" default-value="classpath:/izpack/install.png"
+     * @parameter property="${installer.izpackFrameIconPath}" default-value="classpath:/izpack/install.png"
      */
     protected String izpackFrameIconPath;
     /**
      * Icon to be used on Hello screen
      *
-     * @parameter expression="${installer.izpackHelloIconPath}" default-value="classpath:/izpack/install.png"
+     * @parameter property="${installer.izpackHelloIconPath}" default-value="classpath:/izpack/install.png"
      */
     protected String izpackHelloIconPath;
     /**
      * Definition of additional installer packs
      *
-     * @parameter expression="${installer.izpackAdditionalPacksPath}" default-value="classpath:/izpack/addpacks.xml"
+     * @parameter property="${installer.izpackAdditionalPacksPath}" default-value="classpath:/izpack/addpacks.xml"
      */
     protected String izpackAdditionalPacksPath;
     /**
      * Definition of additional resources
      *
-     * @parameter expression="${installer.izpackAdditionalResourcePaths}"
+     * @parameter property="${installer.izpackAdditionalResourcePaths}"
      */
     protected List<String> izpackAdditionalResourcePaths;
 
@@ -174,38 +172,38 @@ public abstract class SettingsMojo extends AbstractMojo {
      * For non-ASCII service display name and description non-ASCII characters must be encoded in
      * .bat files in appropriate MS-DOS CpXXX encoding
      *
-     * @parameter expression="${installer.prunsrvScriptsEncoding}" default-value="UTF-8"
+     * @parameter property="${installer.prunsrvScriptsEncoding}" default-value="UTF-8"
      */
     protected String prunsrvScriptsEncoding;
     /**
      * Name of the launcher JAR file
      *
-     * @parameter expression="${installer.prunsrvLauncherJarFile}" default-value="${project.artifactId}.jar"
+     * @parameter property="${installer.prunsrvLauncherJarFile}" default-value="${project.artifactId}.jar"
      */
     protected String prunsrvLauncherJarFile;
     /**
      * Name of the launcher JAR file
      *
-     * @parameter expression="${installer.prunsrvStartupMode}" default-value="auto"
+     * @parameter property="${installer.prunsrvStartupMode}" default-value="auto"
      */
     protected String prunsrvStartupMode;
     /**
      * Windows service name
      *
-     * @parameter expression="${installer.prunsrvServiceName}" default-value="${project.artifactId}"
+     * @parameter property="${installer.prunsrvServiceName}" default-value="${project.artifactId}"
      */
     protected String prunsrvServiceName;
     /**
      * Start class that will be used with prunsrv
      *
-     * @parameter expression="${installer.prunsrvStartClass}" default-value="com.alexkasko.installer.StandardLauncher"
+     * @parameter property="${installer.prunsrvStartClass}" default-value="com.alexkasko.installer.StandardLauncher"
      */
     protected String prunsrvStartClass;
     /**
      * Application class implementing com.alexkasko.installer.DaemonLauncher.
      * Will be called by StandardLauncher (prunsrvStartClass) by default
      *
-     * @parameter expression="${installer.prunsrvDaemonLauncherClass}"
+     * @parameter property="${installer.prunsrvDaemonLauncherClass}"
      * @required
      */
     protected String prunsrvDaemonLauncherClass;
@@ -213,99 +211,99 @@ public abstract class SettingsMojo extends AbstractMojo {
      * Input params for prunsrvStartMethod
      * Default value 'start;${installer.prunsrvDaemonLauncherClass}' will be substituted in getter
      *
-     * @parameter expression="${installer.prunsrvStartParams}"
+     * @parameter property="${installer.prunsrvStartParams}"
      */
     protected String prunsrvStartParams;
     /**
      * Stop class that will be used with prunsrv
      * Default value '${installer.prunsrvDaemonLauncherClass}' will be substituted in getter
      *
-     * @parameter expression="${installer.prunsrvStopClass}" default-value="com.alexkasko.installer.StandardLauncher"
+     * @parameter property="${installer.prunsrvStopClass}" default-value="com.alexkasko.installer.StandardLauncher"
      */
     protected String prunsrvStopClass;
     /**
      * Input params for prunsrvStopParams
      * Default value 'stop;${installer.prunsrvDaemonLauncherClass}' will be substituted in getter
      *
-     * @parameter expression="${installer.prunsrvStopParams}"
+     * @parameter property="${installer.prunsrvStopParams}"
      */
     protected String prunsrvStopParams;
     /**
      * JVM options, delimiter is ';', use separate maven options for XMs, XMx and XSs
      *
-     * @parameter expression="${installer.prunsrvJvmOptions}"
+     * @parameter property="${installer.prunsrvJvmOptions}"
      */
     protected String prunsrvJvmOptions = "";
     /**
      * JVM XMs option in MB
      *
-     * @parameter expression="${installer.prunsrvJvmMs}" default-value="64"
+     * @parameter property="${installer.prunsrvJvmMs}" default-value="64"
      */
     protected int prunsrvJvmMs;
     /**
      * JVM XMx option in MB
      *
-     * @parameter expression="${installer.prunsrvJvmMx}" default-value="1024"
+     * @parameter property="${installer.prunsrvJvmMx}" default-value="1024"
      */
     protected int prunsrvJvmMx;
     /**
      * JVM XSs option in KB
      *
-     * @parameter expression="${installer.prunsrvJvmSs}" default-value="512"
+     * @parameter property="${installer.prunsrvJvmSs}" default-value="512"
      */
     protected int prunsrvJvmSs;
     /**
      * Windows service display name
      *
-     * @parameter expression="${installer.prunsrvDisplayName}" default-value="${project.name}"
+     * @parameter property="${installer.prunsrvDisplayName}" default-value="${project.name}"
      */
     protected String prunsrvDisplayName;
     /**
      * Windows service description
      *
-     * @parameter expression="${installer.prunsrvDescription}" default-value="${project.name}"
+     * @parameter property="${installer.prunsrvDescription}" default-value="${project.name}"
      */
     protected String prunsrvDescription;
     /**
      * Prunsrv service stop timeout in seconds
      *
-     * @parameter expression="${installer.prunsrvStopTimeout}" default-value="0"
+     * @parameter property="${installer.prunsrvStopTimeout}" default-value="0"
      */
     protected int prunsrvStopTimeout;
     /**
      * Prunsrv log path, relative to APP_ROOT
      *
-     * @parameter expression="${installer.prunsrvLogPath}" default-value="logs"
+     * @parameter property="${installer.prunsrvLogPath}" default-value="logs"
      */
     protected String prunsrvLogPath;
     /**
      * Prunsrv log prefix
      *
-     * @parameter expression="${installer.prunsrvLogPrefix}" default-value="daemon"
+     * @parameter property="${installer.prunsrvLogPrefix}" default-value="daemon"
      */
     protected String prunsrvLogPrefix;
     /**
      * Prunsrv log level
      *
-     * @parameter expression="${installer.prunsrvLogLevel}" default-value="INFO"
+     * @parameter property="${installer.prunsrvLogLevel}" default-value="INFO"
      */
     protected String prunsrvLogLevel;
       /**
      * Std out file, relative to APP_ROOT
      *
-     * @parameter expression="${installer.prunsrvStdOutput}" default-value="logs\\std_out.txt"
+     * @parameter property="${installer.prunsrvStdOutput}" default-value="logs\\std_out.txt"
      */
     protected String prunsrvStdOutput;
     /**
      * Std out file, relative to APP_ROOT
      *
-     * @parameter expression="${installer.prunsrvStdError}" default-value="logs\\std_err.txt"
+     * @parameter property="${installer.prunsrvStdError}" default-value="logs\\std_err.txt"
      */
     protected String prunsrvStdError;
     /**
      * Whether to start service immediately after installation
      *
-     * @parameter expression="${installer.prunsrvStartOnInstrall}" default-value="true"
+     * @parameter property="${installer.prunsrvStartOnInstrall}" default-value="true"
      */
     protected boolean prunsrvStartOnInstrall;
 
@@ -314,25 +312,25 @@ public abstract class SettingsMojo extends AbstractMojo {
     /**
      * Base directory of compilation process
      *
-     * @parameter expression="${installer.baseDir}" default-value="${project.build.directory}/izpack"
+     * @parameter property="${installer.baseDir}" default-value="${project.build.directory}/izpack"
      */
     protected File izpackDir;
     /**
      * Directory of distribution before for packaging
      *
-     * @parameter expression="${installer.distDir}" default-value="${project.build.directory}/izpack/dist"
+     * @parameter property="${installer.distDir}" default-value="${project.build.directory}/izpack/dist"
      */
     protected File distDir;
     /**
      * IzPack config file
      *
-     * @parameter expression="${installer.installConfigFile}"
+     * @parameter property="${installer.installConfigFile}"
      */
     protected File installConfigFile;
     /**
      * Base directory of compilation process
      *
-     * @parameter expression="${installer.buildOutputFile}" default-value="${project.build.directory}/izpack/build.log"
+     * @parameter property="${installer.buildOutputFile}" default-value="${project.build.directory}/izpack/build.log"
      */
     protected File buildOutputFile;
     /**
@@ -345,19 +343,19 @@ public abstract class SettingsMojo extends AbstractMojo {
     /**
      * Output file (installer)
      *
-     * @parameter expression="${installer.installerOutputFile}" default-value="${project.build.directory}/${project.artifactId}-${project.version}-installer.zip"
+     * @parameter property="${installer.installerOutputFile}" default-value="${project.build.directory}/${project.artifactId}-${project.version}-installer.zip"
      */
     protected File installerOutputFile;
     /**
      * Whether to build unix tar.gz distribution
      *
-     * @parameter expression="${installer.buildUnixDist}" default-value="false"
+     * @parameter property="${installer.buildUnixDist}" default-value="false"
      */
     protected boolean buildUnixDist;
     /**
      * Output file (distibution)
      *
-     * @parameter expression="${installer.distOutputFile}" default-value="${project.build.directory}/${project.artifactId}-dist.tgz"
+     * @parameter property="${installer.distOutputFile}" default-value="${project.build.directory}/${project.artifactId}-dist.tgz"
      */
     protected File distOutputFile;
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
     <groupId>com.alexkasko.installer</groupId>
     <artifactId>windows-service-installer-parent</artifactId>
     <version>1.0.7-SNAPSHOT</version>
@@ -68,12 +65,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.5.1</version>
+                    <version>2.8</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -99,6 +96,18 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.2</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>ru.concerteza.buildnumber</groupId>
                 <artifactId>maven-jgit-buildnumber-plugin</artifactId>
                 <version>1.2.7</version>
@@ -115,61 +124,71 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadoc</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <linksource>true</linksource>
-                            <quiet>true</quiet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.4</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                        <configuration>
-                            <passphrase>nopwd</passphrase>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <pushChanges>false</pushChanges>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
-                    <localCheckout>true</localCheckout>
-                </configuration>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <linksource>true</linksource>
+                                    <quiet>true</quiet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <passphrase>nopwd</passphrase>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <version>2.3.2</version>
+                        <configuration>
+                            <pushChanges>false</pushChanges>
+                            <tagNameFormat>@{project.version}</tagNameFormat>
+                            <localCheckout>true</localCheckout>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/windows-service-installer-common/pom.xml
+++ b/windows-service-installer-common/pom.xml
@@ -10,22 +10,6 @@
     <packaging>jar</packaging>
     <name>Maven Windows Service Installer Common Library</name>
 
-    <description>
-        Maven plugin to build installers with Windows service support.
-    </description>
-    <url>https://github.com/alexkasko/windows-service-installer</url>
-    <licenses>
-        <license>
-            <name>Apache License 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-    </licenses>
-    <scm>
-        <url>https://github.com/alexkasko/windows-service-installer</url>
-        <connection>scm:git:https://github.com/alexkasko/windows-service-installer.git</connection>
-        <developerConnection>scm:git:https://github.com/alexkasko/windows-service-installer.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
     <developers>
         <developer>
             <name>Alex Kasko</name>

--- a/windows-service-installer-test/pom.xml
+++ b/windows-service-installer-test/pom.xml
@@ -10,22 +10,6 @@
     <packaging>jar</packaging>
     <name>Maven Windows Service Installer Test Suite</name>
 
-    <description>
-        Maven plugin to build installers with Windows service support.
-    </description>
-    <url>https://github.com/alexkasko/windows-service-installer</url>
-    <licenses>
-        <license>
-            <name>Apache License 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-    </licenses>
-    <scm>
-        <url>https://github.com/alexkasko/windows-service-installer</url>
-        <connection>scm:git:https://github.com/alexkasko/windows-service-installer.git</connection>
-        <developerConnection>scm:git:https://github.com/alexkasko/windows-service-installer.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
     <developers>
         <developer>
             <name>Alex Kasko</name>


### PR DESCRIPTION
Very nice plugin here! It's a gentle introduction to the izpack and PrunSrv tools. I made a few changes here to update the plugin with the latest version of some of the libraries and also fixed a minor issue with I/O. 
- ensure that OutputStream is closed in FtlCopyFunction
- fixed maven plugin warnings about deprecated parameter syntax
- updated spring version to 4 (spring 3x has published CVE's which make place it on do-not-use lists)
- removed redundant info from pom's since they inherit the description/license/scm from the parent
- updated the maven-site-plugin and maven-project-info-reports-plugin to work with Maven 3.1.x
- removed dependency on OSSH parent module in favor of the nexus-staging-maven-plugin and moved the javadoc, gpg, and release plugins to a profile
